### PR TITLE
Use meta-updater/scripts/run-qemu-ota.

### DIFF
--- a/_posts/2017-05-16-qemuvirtualbox.adoc
+++ b/_posts/2017-05-16-qemuvirtualbox.adoc
@@ -20,7 +20,7 @@ include::../_pages/quickstarts/raspberry-pi.adoc[tags=prereqs;provisioning;env-s
 The build process creates disk images as an artefact. You can then directly run them with QEMU. (If you don't already have it installed, install it with `apt-get install qemu` or similar.) The meta-updater layer contains a helper script to launch the images:
 
 ----
-../meta-updater-qemux86-64/scripts/run-qemu [image name] [mac address]
+../meta-updater/scripts/run-qemu-ota [image name] [mac address]
 ----
 
 Both arguments are optional; image name defaults to `core-image-minimal`, and if a mac address isn't specified, a random one is generated.
@@ -30,7 +30,7 @@ Both arguments are optional; image name defaults to `core-image-minimal`, and if
 By default, QEMU will run your image in snapshot mode, *discarding any changes you made* to the disk image as soon as it exits. If you want to have a persistent VM, you need to create an link:https://wiki.archlinux.org/index.php/QEMU#Overlay_storage_images[overlay storage image] in qcow2 format. The helper script can also manage this for you, making it easy to create an emulated fleet of devices:
 
 ----
-../meta-updater-qemux86-64/scripts/run-qemu --overlay mydevice.cow
+../meta-updater/scripts/run-qemu-ota --overlay mydevice.cow
 ----
 
 If the specified overlay image doesn't yet exist, it will be created first, or launched directly if it does exist.


### PR DESCRIPTION
meta-updater-qemux86-64/scripts/run-qemu is now obsolete and redundant.

See also https://github.com/advancedtelematic/meta-updater-qemux86-64/pull/12

Note that I am *not* removing meta-updater-qemux86-64/scripts/run-qemu from morty (unless you think I should).