### PR TITLE
CSS fix: add scrollbars to horizontal code blocks instead of wrap

### DIFF
--- a/css/here.css
+++ b/css/here.css
@@ -1,4 +1,3 @@
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 @font-face { font-family: "Fira Mono"; src: url("../fonts/FiraMono/FiraMono-Regular.eot");
   /* IE9 Compat Modes */
   src: local("Fira Mono"), url("../fonts/FiraMono/FiraMono-Regular.eot?#iefix") format("embedded-opentype"), url("../fonts/FiraMono/FiraMono-Regular.woff2") format("woff2"), url("../fonts/FiraMono/FiraMono-Regular.woff") format("woff"), url("../fonts/FiraMono/FiraMono-Regular.ttf") format("truetype");
@@ -20,68 +19,69 @@
 
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
-
+/** Correct `block` display not defined in IE 8/9. */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
-
+/** Correct `inline-block` display not defined in IE 8/9. */
 audio, canvas, video { display: inline-block; }
 
-
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
 audio:not([controls]) { display: none; height: 0; }
 
-
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
 [hidden], template { display: none; }
 
 script { display: none !important; }
 
 /* ========================================================================== Base ========================================================================== */
-
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
 html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
-
+/** Remove default margin. */
+body { margin: 0; }
 
 /* ========================================================================== Links ========================================================================== */
-
+/** Remove the gray background color from active links in IE 10. */
 a { background: transparent; }
 
-
+/** Address `outline` inconsistency between Chrome and other browsers. */
 a:focus { outline: thin dotted; }
 
-
+/** Improve readability when focused and also mouse hovered in all browsers. */
 a:active, a:hover { outline: 0; }
 
 /* ========================================================================== Typography ========================================================================== */
-
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
 h1 { font-size: 2em; margin: 0.67em 0; }
 
-
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
 abbr[title] { border-bottom: 1px dotted; }
 
-
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
 b, strong { font-weight: bold; }
 
-
+/** Address styling not present in Safari 5 and Chrome. */
 dfn { font-style: italic; }
 
-
+/** Address differences between Firefox and other browsers. */
 hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-
+/** Address styling not present in IE 8/9. */
 mark { background: #ff0; color: #000; }
 
-
+/** Correct font family set oddly in Safari 5 and Chrome. */
 code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 
-
+/** Improve readability of pre-formatted text in all browsers. */
 pre { white-space: pre-wrap; }
 
-
+/** Set consistent quote types. */
 q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 
-
+/** Address inconsistent and variable font size in all browsers. */
 small { font-size: 80%; }
 
-
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
 sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
 sup { top: -0.5em; }
@@ -89,55 +89,55 @@ sup { top: -0.5em; }
 sub { bottom: -0.25em; }
 
 /* ========================================================================== Embedded content ========================================================================== */
-
+/** Remove border when inside `a` element in IE 8/9. */
 img { border: 0; }
 
-
+/** Correct overflow displayed oddly in IE 9. */
 svg:not(:root) { overflow: hidden; }
 
 /* ========================================================================== Figures ========================================================================== */
-
+/** Address margin not present in IE 8/9 and Safari 5. */
 figure { margin: 0; }
 
 /* ========================================================================== Forms ========================================================================== */
-
+/** Define consistent border, margin, and padding. */
 fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
 legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
-
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
 button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
 
-
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
 button, input { line-height: normal; }
 
-
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
 button, select { text-transform: none; }
 
-
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
 button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
-
+/** Re-set default cursor for disabled elements. */
 button[disabled], html input[disabled] { cursor: default; }
 
-
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
 input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
-
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
 input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
 
-
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
 input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-
+/** Remove inner padding and border in Firefox 4+. */
 button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
 textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
 
 /* ========================================================================== Tables ========================================================================== */
-
+/** Remove most spacing between table cells. */
 table { border-collapse: collapse; border-spacing: 0; }
 
 meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
@@ -150,7 +150,7 @@ meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; wi
 
 html, body { font-size: 100%; }
 
-body { background: white; color: rgba(0, 0, 0, 0.8); padding: 0; margin: 0; font-family: "Fira Sans Go", "Noto Serif", "DejaVu Serif", serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; tab-size: 4; -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased;}
+body { background: white; color: rgba(0, 0, 0, 0.8); padding: 0; margin: 0; font-family: "Fira Sans Go", "Noto Serif", "DejaVu Serif", serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
 a:hover { cursor: pointer; }
 
@@ -176,13 +176,15 @@ img { -ms-interpolation-mode: bicubic; }
 
 .hide { display: none; }
 
+.antialiased { -webkit-font-smoothing: antialiased; }
 
-img, object, svg { display: inline-block; vertical-align: middle; }
+img { display: inline-block; vertical-align: middle; }
 
 textarea { height: auto; min-height: 50px; }
 
 select { width: 100%; }
 
+object, svg { display: inline-block; vertical-align: middle; }
 
 .center { margin-left: auto; margin-right: auto; }
 
@@ -235,6 +237,7 @@ code { font-family: "Fira Mono", "Courier New", Courier, monospace; font-weight:
 ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 1.25em; list-style-position: outside; font-family: inherit; }
 
 ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
 
 /* Unordered Lists */
 ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
@@ -242,6 +245,7 @@ ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
 ul.square { list-style-type: square; }
 ul.circle { list-style-type: circle; }
 ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
 
 /* Ordered Lists */
 ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
@@ -278,12 +282,13 @@ blockquote, blockquote p { line-height: 1.6; color: rgba(0, 0, 0, 0.85); }
   h4 { font-size: 1.4375em; } }
 /* Tables */
 table { background: white; margin-bottom: 1.25em; border: solid 1px #dedede; }
-table thead, table tfoot { background: #f7f8f7; }
+table thead, table tfoot { background: #f7f8f7; font-weight: bold; }
 table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: rgba(0, 0, 0, 0.8); text-align: left; }
 table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: rgba(0, 0, 0, 0.8); }
 table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #f8f8f7; }
 table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.6; }
 
+body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
 
 h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.2; word-spacing: -0.05em; }
 h1 strong, h2 strong, h3 strong, #toctitle strong, .sidebarblock > .content > .title strong, h4 strong, h5 strong, h6 strong { font-weight: 400; }
@@ -736,6 +741,8 @@ p { margin-bottom: 1.25rem; }
 a { border-bottom: 4px solid #00afaa; color: rgba(0, 0, 0, 0.675); text-decoration: none; }
 
 a:hover, a:focus { color: rgba(0, 0, 0, 0.675); border-bottom: 4px solid #bebebe; text-decoration: none; }
+
+pre, pre > code { white-space: pre; overflow-x: auto; word-break: normal; word-wrap: normal; }
 
 .print-only { display: none !important; }
 


### PR DESCRIPTION
This one was annoying me: we have a few places where the code is longer than the default width of the code box, and it was wrapping the lines. This fixes it.