### PR TITLE
OTA-877 Fix garage-sign procedure and split "install garage-sign/deploy"

### DIFF
--- a/_pages/prod/install-garage-sign-deploy.adoc
+++ b/_pages/prod/install-garage-sign-deploy.adoc
@@ -1,0 +1,1 @@
+../../_posts/2018-09-13-install-garage-sign-deploy.adoc

--- a/_posts/2018-02-08-rotating-signing-keys.adoc
+++ b/_posts/2018-02-08-rotating-signing-keys.adoc
@@ -14,35 +14,9 @@
 As part of the quickstart, your {product-name} account creates initial keys and stores them online.
 Before using {product-name} in production, however, you should create offline keys that you manage yourself, then rotate out the initial online keys.
 
+Before you start, make sure that you've installed the link:install-garage-sign-deploy.html[`garage-deploy`] tool first. This tool includes the `garage-sign` utility, which you'll need for this procedure.
+
 toc::[]
-
-== Install the `garage-sign` tool
-
-On a Ubuntu 16.04 machine, download the `garage-deploy` package and install it:
-
-[subs="attributes"]
-----
-wget https://github.com/advancedtelematic/aktualizr/releases/download/{garage-deploy-version}/garage_deploy.deb
-sudo apt install ./garage_deploy.deb
-----
-
-[TIP]
-====
-This package is built against Ubuntu 16.04 and may work for other distributions, but if it doesn't work for your setup, you can checkout https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}[aktualizr] and build the deb package or binary yourself:
-
-[subs="attributes"]
-----
-git clone --branch {garage-deploy-version} --recursive https://github.com/advancedtelematic/aktualizr
-cd aktualizr
-mkdir build
-cd build
-cmake -DBUILD_SOTA_TOOLS=ON ..
-make package # Or just `make` to get the binary
-sudo apt install ./garage_deploy.deb
-----
-====
-
-The package contains both the `garage-deploy` and `garage-sign` tools, but for rotating keys we will only need `garage-sign`.
 
 == Rotate the TUF `root` and `targets` keys
 

--- a/_posts/2018-03-15-crossdeploying-device-images-to-a-different-account.adoc
+++ b/_posts/2018-03-15-crossdeploying-device-images-to-a-different-account.adoc
@@ -7,46 +7,18 @@
 :sectnums:
 :garage-deploy-version: 2018.11
 
-For our recommended production workflow, you will need to move device images from one account to another from time to time--for example, sending a development build you're happy with to the QA team, or sending that build to the deployment team once it's passed QA. We provide a tool called `garage-deploy` for doing just that.
+For our recommended production workflow, you will need to move device images from one account to another from time to time. For example, you might want to send a development build that you're happy with to the QA team, or send that build to the deployment team once it's passed QA. You can do this with our `garage-deploy` tool.
 
-. Install the `garage-deploy` tool
-+
-NOTE: If you've link:../prod/rotating-signing-keys.html[rotated your signing keys] already, `garage-deploy` will already be installed, and you can skip this step.
-+
-We currently provide released versions of `garage-deploy` for Ubuntu 18.04 (Bionic) and Ubuntu 16.04 (Xenial) which are available on https://github.com/advancedtelematic/aktualizr/releases/tag/{garage-deploy-version}.
-On a Ubuntu 18.04 machine, download the `garage-deploy` package and install it:
-+
-[subs="attributes"]
-----
-wget https://github.com/advancedtelematic/aktualizr/releases/download/{garage-deploy-version}/garage_deploy-ubuntu_18.04.deb
-sudo apt install ./garage_deploy-ubuntu_18.04.deb
-----
-+
-[TIP]
-====
-These packages are specific to the distributions they were built for. If yours is not in the list, you can checkout https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}[aktualizr], install the required dependencies link:https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}#dependencies[listed here] (exact package names may vary) and build the deb package yourself:
+Before you start, make sure that you've installed the link:install-garage-sign-deploy.html[`garage-deploy`] tool first.
 
-[subs="attributes"]
-----
-git clone --branch {garage-deploy-version} --recursive https://github.com/advancedtelematic/aktualizr
-cd aktualizr
-mkdir build
-cd build
-cmake -DBUILD_SOTA_TOOLS=ON ..
-make package
-sudo apt install ./garage_deploy.deb
-----
-
-Building a package will only work on Debian-based distributions. For other environments, it's possible to directly run the executable by itself: run `make garage-deploy` after the CMake invocation and the executable will be available in `build/src/sota_tools/garage-deploy`.
-====
+To cross-deploy device images to a different account, follow these steps: ::
+. link:../quickstarts/generating-provisioning-credentials.html[Download provisioning keys] for both accounts.
 +
-. Download `credentials.zip` files for both accounts
-+
-These can be found on the provisioning keys page. We'll assume you named them `source-credentials.zip` and `dest-credentials.zip`.
+We'll assume that you named them `source-credentials.zip` and `dest-credentials.zip`.
 +
 . Select an image and commit ID to deploy, and the hardware ID(s) to deploy it to
 +
-The image name is the one that appears in your {product-name} account--it will be the same as the `MACHINE` setting in Yocto by default, or the `OSTREE_BRANCHNAME` option if you set it. The commit ID is the hash of the OSTree commit, visible in the package details. The hardware IDs are for the destination account, and are equivalent to the `MACHINE` setting in your yocto build.
+The image name is the one that appears in your {product-name} account--it will be the same as the `MACHINE` setting in Yocto by default, or the `OSTREE_BRANCHNAME` option if you set it. The commit ID is the hash of the OSTree commit, visible in the package details. The hardware IDs are for the destination account, and are equivalent to the `MACHINE` setting in your Yocto build.
 +
 . Run `garage-deploy`
 +

--- a/_posts/2018-08-29-generate-and-install-a-root-certificate.adoc
+++ b/_posts/2018-08-29-generate-and-install-a-root-certificate.adoc
@@ -2,7 +2,7 @@
 :page-layout: page
 :page-categories: [prod]
 :page-date: 2018-08-29 11:12:06
-:page-order: 2
+:page-order: 3
 :icons: font
 
 Before you can get started with implicit provisioning, you'll need the following components:

--- a/_posts/2018-09-13-install-garage-sign-deploy.adoc
+++ b/_posts/2018-09-13-install-garage-sign-deploy.adoc
@@ -1,0 +1,51 @@
+= Install the "garage deploy" tool
+:page-layout: page
+:page-categories: [prod]
+:page-date: 2018-09-13 11:50:24
+:page-order: 2
+:icons: font
+:garage-deploy-version: 2018.11
+
+For our recommended production workflow, we recommend some extra security procedures. Before you can follow these procedures, you need to install our `garage-deploy` tool first.
+
+We currently provide released versions of `garage-deploy` for Ubuntu 18.04 (Bionic) and Ubuntu 16.04 (Xenial) which are available on https://github.com/advancedtelematic/aktualizr/releases/tag/{garage-deploy-version}.
+
+* To install `garage-deploy` on an Ubuntu 18.04 machine, download the `garage-deploy` package and install it with the following command:
++
+[subs="attributes"]
+----
+wget https://github.com/advancedtelematic/aktualizr/releases/download/{garage-deploy-version}/garage_deploy-ubuntu_18.04.deb
+sudo apt install ./garage_deploy-ubuntu_18.04.deb
+----
++
+[TIP]
+====
+These packages are specific to the distributions they were built for. If yours is not in the list, you can checkout https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}[aktualizr], install the required dependencies link:https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}#dependencies[listed here] (exact package names may vary) and build the deb package yourself:
+
+[subs="attributes"]
+----
+git clone --branch {garage-deploy-version} --recursive https://github.com/advancedtelematic/aktualizr
+cd aktualizr
+mkdir build
+cd build
+cmake -DBUILD_SOTA_TOOLS=ON ..
+make package
+sudo apt install ./garage_deploy.deb
+----
+
+Building a package will only work on Debian-based distributions. For other environments, it's possible to directly run the executable by itself: run `make garage-deploy` after the CMake invocation and the executable will be available in `build/src/sota_tools/garage-deploy`.
+====
+
+Once you've installed `garage-deploy` tool, you're ready to perform the following tasks:
+
+* Move device images from one account to another--for example, to send a development build to the QA team, or to send a release candidate to the deployment team.
++
+For more information, see "link:crossdeploying-device-images-to-a-different-account.html[Cross-deploy device images to a different account]".
++
+* Create offline signing keys that you manage yourself and rotate out the installed online keys. 
++
+For more information, see "link:rotating-signing-keys.html[Rotate signing keys]".
+
+
+
+

--- a/_posts/2018-09-13-install-garage-sign-deploy.adoc
+++ b/_posts/2018-09-13-install-garage-sign-deploy.adoc
@@ -10,21 +10,38 @@ For our recommended production workflow, we recommend some extra security proced
 
 We currently provide released versions of `garage-deploy` for Ubuntu 18.04 (Bionic) and Ubuntu 16.04 (Xenial) which are available on https://github.com/advancedtelematic/aktualizr/releases/tag/{garage-deploy-version}.
 
-* To install `garage-deploy` on an Ubuntu 18.04 machine, download the `garage-deploy` package and install it with the following command:
-+
+== Installation instructions
+
+=== Ubuntu 18.04 or 16.04
+
+To install `garage-deploy` on an Ubuntu 18.04 machine, download the `garage-deploy` package and install it with the following command:
+
 [subs="attributes"]
 ----
 wget https://github.com/advancedtelematic/aktualizr/releases/download/{garage-deploy-version}/garage_deploy-ubuntu_18.04.deb
 sudo apt install ./garage_deploy-ubuntu_18.04.deb
 ----
-+
-[TIP]
-====
-These packages are specific to the distributions they were built for. If yours is not in the list, you can checkout https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}[aktualizr], install the required dependencies link:https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}#dependencies[listed here] (exact package names may vary) and build the deb package yourself:
+
+For Ubuntu 16.04:
+
+[subs="attributes"]
+----
+wget https://github.com/advancedtelematic/aktualizr/releases/download/{garage-deploy-version}/garage_deploy-ubuntu_16.04.deb
+sudo apt install ./garage_deploy-ubuntu_16.04.deb
+----
+
+=== Other debian-based distros or versions
+
+If you're using another version of Ubuntu, or another Debian-based distribution that we don't provide packages for, you can build a .deb yourself. Check out https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}[aktualizr], install the required dependencies link:https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}#dependencies[listed here] (exact package names may vary) and build the deb package yourself:
 
 [subs="attributes"]
 ----
 git clone --branch {garage-deploy-version} --recursive https://github.com/advancedtelematic/aktualizr
+sudo apt install asn1c build-essential clang clang-check-3.8 clang-format-3.8 clang-tidy-3.8 cmake curl \
+  doxygen graphviz lcov libarchive-dev libboost-dev libboost-filesystem-dev libboost-log-dev \
+  libboost-program-options-dev libboost-serialization-dev libboost-iostreams-dev libcurl4-openssl-dev \
+  libdpkg-dev libostree-dev libp11-2 libp11-dev libpthread-stubs0-dev libsodium-dev libsqlite3-dev \
+  libssl-dev libsystemd-dev
 cd aktualizr
 mkdir build
 cd build
@@ -33,16 +50,34 @@ make package
 sudo apt install ./garage_deploy.deb
 ----
 
-Building a package will only work on Debian-based distributions. For other environments, it's possible to directly run the executable by itself: run `make garage-deploy` after the CMake invocation and the executable will be available in `build/src/sota_tools/garage-deploy`.
-====
+=== Binaries for other distros
+
+If you're using a non-debian-based distro, you will need to build and install the binary directly.
+
+First, install the required dependencies link:https://github.com/advancedtelematic/aktualizr/tree/{garage-deploy-version}#dependencies[listed here]. (These are the Ubuntu package names; the packages may be named differently in your distro's repositories.) Then, you can build as above, but with `garage-deploy` as the make target:
+
+[subs="attributes"]
+----
+git clone --branch {garage-deploy-version} --recursive https://github.com/advancedtelematic/aktualizr
+cd aktualizr
+mkdir build
+cd build
+cmake -DBUILD_SOTA_TOOLS=ON ..
+make garage-deploy
+sudo apt install ./garage_deploy.deb
+----
+
+The executable will be available in `build/src/sota_tools/garage-deploy`.
+
+== Usage
 
 Once you've installed `garage-deploy` tool, you're ready to perform the following tasks:
 
 * Move device images from one account to another--for example, to send a development build to the QA team, or to send a release candidate to the deployment team.
 +
 For more information, see "link:crossdeploying-device-images-to-a-different-account.html[Cross-deploy device images to a different account]".
-+
-* Create offline signing keys that you manage yourself and rotate out the installed online keys. 
+
+* Create offline signing keys that you manage yourself and rotate out the installed online keys.
 +
 For more information, see "link:rotating-signing-keys.html[Rotate signing keys]".
 


### PR DESCRIPTION
Created a separate procedure to install Garage Deploy and linked to it from the affected procedures. Ensured that it's the most up to date procedure for Ubuntu 18.