### PR TITLE
Remove instructions about manually updating AGL layer

### DIFF
--- a/_posts/2017-05-16-automotive-grade-linux.adoc
+++ b/_posts/2017-05-16-automotive-grade-linux.adoc
@@ -26,7 +26,7 @@ First, clone a manifest file for AGL Electric Eel:
 ----
 mkdir myproject
 cd myproject
-repo init -b eel -m eel_5.1.0.xml -u https://gerrit.automotivelinux.org/gerrit/AGL/AGL-repo.git
+repo init -b eel -m default.xml -u https://gerrit.automotivelinux.org/gerrit/AGL/AGL-repo.git
 repo sync
 ----
 
@@ -38,14 +38,6 @@ Yocto is a set of tools, templates and methods for building Linux systems from s
 
 All of these layers are assembled into a built Linux system by Bitbake, the build tool of the Yocto Project, based on the instructions in the recipes inside the layers.
 ****
-
-==== Recommended: update to the latest meta-updater
-
-AGL Eel packages an out-of-date version of meta-updater. We strongly recommend checking out the tip of the `pyro` branch, instead:
-
-----
-git -C meta-updater/ checkout pyro
-----
 
 === Run environment setup script
 


### PR DESCRIPTION
AGL has fixed some stuff, and bumped the version of meta-updater in
AGL-repo to the tip of pyro, so we no longer need special
instructions to fix that.

Signed-off-by: Jon Oster <jon.oster@here.com>